### PR TITLE
Allow local onError override

### DIFF
--- a/src/ensure.ts
+++ b/src/ensure.ts
@@ -7,7 +7,7 @@ import type {
 } from "./types";
 
 export function createEnsure(options: CreateEnsureOptions = {}) {
-  const { environment, onError } = options;
+  const { environment, onError: onErrorGlobal } = options;
 
   async function ensure<T>(
     fn: () => Promise<T>,
@@ -20,10 +20,12 @@ export function createEnsure(options: CreateEnsureOptions = {}) {
       exponentialBackoff = false,
       timeout,
       onRetry = () => {},
+      onError: onErrorLocal = undefined,
     } = options;
 
     let retryCount = 0;
     let lastError: unknown;
+    const onError = onErrorLocal ?? onErrorGlobal;
 
     const env = environment || process.env.NODE_ENV;
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -14,6 +14,7 @@ export interface EnsureOptions {
   exponentialBackoff?: boolean;
   timeout?: number;
   onRetry?: (attempt: number, error: unknown) => void;
+  onError?: (error: unknown) => Promise<void>;
 }
 
 export type EnsureSuccess<T> = {


### PR DESCRIPTION
Adds option to define the onError handler when calling `ensure()`. Defining `onError` during the function call will override the handler defined in the constructor.